### PR TITLE
feat: SEO para la web en general

### DIFF
--- a/src/components/admin/blogs/AddBlogModel.tsx
+++ b/src/components/admin/blogs/AddBlogModel.tsx
@@ -347,7 +347,7 @@ const AddBlogModal: React.FC<AddBlogModalProps> = ({
     const after = parrafoActual.substring(end);
 
     const productUrl = `/productos/detalle?link=${productoSeleccionado.link}`;
-    const linkedProductText = `<a href="${productUrl}" style="text-decoration: underline;">${selectedText}</a>`;
+    const linkedProductText = `<a href="${productUrl}" style="text-decoration: underline;" title="${productoSeleccionado.link}">${selectedText}</a>`;
     const newValue = before + linkedProductText + after;
 
     const nuevosParrafos = [...formData.imagenes];
@@ -383,7 +383,7 @@ const AddBlogModal: React.FC<AddBlogModalProps> = ({
     const before = parrafoActual.substring(0, start);
     const after = parrafoActual.substring(end);
 
-    const linkedText = `<a href="${link.trim()}" style="text-decoration: underline;">${selectedText}</a>`;
+    const linkedText = `<a href="${link.trim()}" style="text-decoration: underline;" title="${selectedText}">${selectedText}</a>`;
     const newValue = before + linkedText + after;
 
     const nuevosParrafos = [...formData.imagenes];

--- a/src/components/blog/CardBlog.tsx
+++ b/src/components/blog/CardBlog.tsx
@@ -19,6 +19,7 @@ const CardBlog: React.FC<CardBlogProps> = ({ blog }) => {
           <img
               src={`${apiUrl}${blog.miniatura}`}
               alt={blog.titulo}
+              title={blog.titulo}
               loading="lazy"
               className="w-full h-48 object-cover"
           />

--- a/src/components/index/Hero.tsx
+++ b/src/components/index/Hero.tsx
@@ -43,6 +43,7 @@ const Hero = () => {
               srcSet={`${hero.imageMobile} 750w, ${hero.imageDesktop} 1200w`}
               sizes="100vw"
               alt={hero.alt || ""}
+              title={hero.alt || ""}
               loading={index === 0 ? "eager" : "lazy"}
               fetchPriority={index === 0 ? "high" : "auto"}
               className={`absolute inset-0 w-full h-full object-cover object-center transition-opacity duration-1000 ${

--- a/src/components/index/ProductSlideshow.tsx
+++ b/src/components/index/ProductSlideshow.tsx
@@ -143,6 +143,7 @@ const ProductSlideshow = () => {
                 >
                     <a
                         href={getLinkHref(item)}
+                        title="Información del producto"
                         className="w-full h-full font-extrabold text-xl flex flex-col items-center gap-6"
                     >
                         <img

--- a/src/components/index/SectionCard.astro
+++ b/src/components/index/SectionCard.astro
@@ -14,6 +14,7 @@ const props = Astro.props;
     <Image
       src={props.image}
       alt={props.alt}
+      title={props.alt}
       loading={'lazy'}
       width={400}
       height={700}

--- a/src/components/index/Slideshow.tsx
+++ b/src/components/index/Slideshow.tsx
@@ -63,6 +63,7 @@ const Testimonials: React.FC = () => {
               <img
                 src={testimonial.avatar || "https://placehold.co/64x64"}
                 alt="Avatar"
+                title="Avatar"
                 width={64}
                 height={64}
                 className="w-16 h-16 rounded-full object-cover"
@@ -129,6 +130,7 @@ const Testimonials: React.FC = () => {
             <img
               src={testimonial.avatar || "https://via.placeholder.com/64"}
               alt="Avatar"
+              title="Avatar"
               width={64}
               height={64}
               className="w-16 h-16 rounded-full object-cover"

--- a/src/components/ui/ScrollModal.tsx
+++ b/src/components/ui/ScrollModal.tsx
@@ -274,11 +274,13 @@ const ScrollModal = () => {
           <img
             src={asesoriaImg.src}
             alt="Asesoría"
+            title="Asesoría"
             className="w-full h-full object-cover select-none scale-105 transition-transform duration-700"
           />
           <img
             src={Logo.src}
             alt="LogoTami"
+            title="Logo Tami"
             className="absolute top-40 left-4 w-80 h-80 object-contain select-none drop-shadow-2xl animate-fadeIn"
           />
         </div>

--- a/src/components/ui/footer/Footer.astro
+++ b/src/components/ui/footer/Footer.astro
@@ -14,6 +14,7 @@ import CopyText from "./CopyText.astro";
       <img
         src={logoTami.src}
         alt="Logo de Tami"
+        title="Logo de Tami"
         loading="lazy"
         width={120}
         height={60}
@@ -44,6 +45,7 @@ import CopyText from "./CopyText.astro";
     <div class="flex flex-col items-center space-y-8">
       <img
         src={mascotaTami.src}
+        title="Mascota Tami"
         alt="Mascota Tami"
         loading="lazy"
         width={100}

--- a/src/components/ui/navbar/NavBar.tsx
+++ b/src/components/ui/navbar/NavBar.tsx
@@ -160,6 +160,7 @@ function NavBar() {
           {/* WhatsApp */}
           <a
               href="https://api.whatsapp.com/send?phone=51978883199"
+              title="Conéctate con nosotros por WhatsApp"
               target="_blank"
               rel="noopener noreferrer"
               className="transition-transform duration-200 transform hover:scale-110"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ const { title, description, canonicalUrl } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -31,6 +31,9 @@ const { title, description, canonicalUrl } = Astro.props;
 
     <link rel="canonical" href={canonicalUrl} />
     <meta name="generator" content={Astro.generator} />
+    <meta name="author" content="Tamimaquinarias" />
+    <meta name="robots" content="index, follow" />
+    <meta name="publisher" content="Tami Maquinarias">
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     <!-- <style>

--- a/src/pages/blog/details.astro
+++ b/src/pages/blog/details.astro
@@ -9,7 +9,7 @@ const blogsUrl = config.endpoints.blogs;
 ---
 
 {/* Details de blog */}
-<Layout title="Blog Details">
+<Layout title="Blog Details" description="Descripcion por defecto" canonicalUrl="https://tamimaquinarias.com/blog">
   <div class="bg-teal-500 flex flex-col min-h-screen">
     <!-- SECCIÓN HERO -->
     <header class="relative w-full h-screen md:min-h-[80vh]">
@@ -141,6 +141,24 @@ const blogsUrl = config.endpoints.blogs;
         }
 
         const blog = data.data;
+
+        document.title = blog.etiqueta?.meta_titulo || 'Título para blogs por defecto';
+
+        let metaDescription = document.querySelector('meta[name="description"]');
+        if (!metaDescription) {
+          metaDescription = document.createElement('meta');
+          metaDescription.name = "description";
+          document.head.appendChild(metaDescription);
+        }
+        metaDescription.content = blog.etiqueta?.meta_descripcion || 'Descripción por defecto';
+
+        let canonicalLink = document.querySelector('link[rel="canonical"]');
+        if (!canonicalLink) {
+          canonicalLink = document.createElement('link');
+          canonicalLink.rel = 'canonical';
+          document.head.appendChild(canonicalLink);
+        }
+        canonicalLink.href = window.location.href;
 
         function generateBlogJsonLd(blog) {
           const images = [

--- a/src/pages/blog/details.astro
+++ b/src/pages/blog/details.astro
@@ -317,6 +317,7 @@ const blogsUrl = config.endpoints.blogs;
           <img 
             src="${getApiUrl}${imagen.ruta_imagen}" 
             alt="${imagen.text_alt || 'Imagen del blog'}"
+            title="${imagen.text_alt || 'Imagen del blog'}"
             class="block w-auto h-auto max-w-full ${
                 isSecondImage
                     ? 'max-h-[600px] md:max-h-[700px]' // Imagen 2: dejar más alto

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,8 +16,8 @@ import Testimonials from "../components/index/Slideshow";
 ---
 
 <Layout
-  title="Maquinaria para Negocios y Soluciones Comerciales Innovadoras en Perú | Venta a Nivel Nacional Tami Maquinaria Inicio"
-  description="Selladoras, mesas LED, sillas LED, ventiladores holográficos, máquinas de empaque, equipos industriales, maquinaria comercial, maquinaria para negocios, Perú, embalaje, selladora industrial, eventos, productos innovadores, equipos LED, máquinas automáticas, negocio propio, artículos para empresas, atención nacional, máquinas modernas, iluminación LED."
+  title="Maquinaria y Decoración para Negocios"
+  description="Descubre maquinaria y decoración ideal para tu negocio. Compra selladoras, equipos de acabado y productos para emprendedores en Perú."
   canonicalUrl="https://tamimaquinarias.com/"
 >
   {/* Hero principal con CTA */}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,6 +38,7 @@ import Testimonials from "../components/index/Slideshow";
         <Image
           src={manoRobotica}
           alt="Mano robótica apuntando"
+          title="Mano robótica apuntando"
           width={manoRobotica.width}
           height={manoRobotica.height}
           quality={70}
@@ -49,6 +50,7 @@ import Testimonials from "../components/index/Slideshow";
         <Image
           src={circuitos}
           alt="Circuitos electrónicos"
+          title="Circuitos electrónicos"
           class="absolute inset-0 m-auto max-w-3/4 w-full 2xl:w-full z-[-10] hidden md:block"
           loading="lazy"
         />
@@ -113,6 +115,7 @@ import Testimonials from "../components/index/Slideshow";
           <Image
             src={iconGarantia}
             alt="Garantía"
+            title="Garantía"
             width="48"
             height="48"
             class="ml-2 w-10 sm:w-12 lg:w-24"
@@ -130,13 +133,13 @@ import Testimonials from "../components/index/Slideshow";
       <div
         class="flex flex-wrap gap-4 my-6 justify-center lg:justify-start text-white"
       >
-        <a href="/blog" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
+        <a href="/blog" title="Calidad" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
           CALIDAD
         </a>
-        <a href="/blog" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
+        <a href="/blog" title="Innovación" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
           INNOVACIÓN
         </a>
-        <a href="/blog" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
+        <a href="/blog" title="Negocio Propio" class="bg-teal-700 px-4 2xl:px-7 py-2 2xl:py-3 rounded-full transition-all duration-200 hover:bg-teal-800 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-400">
           NEGOCIO PROPIO
         </a>
       </div>
@@ -152,6 +155,7 @@ import Testimonials from "../components/index/Slideshow";
     <Image
       src={trabajo}
       alt="Personal hablando"
+      title="Personal hablando"
       widths={[320, 640, 960, 1200]}
       sizes="(max-width: 640px) 90vw, (max-width: 1024px) 60vw, 40vw"
       width={500}

--- a/src/pages/politicas-de-envio.astro
+++ b/src/pages/politicas-de-envio.astro
@@ -68,6 +68,7 @@ const whatsappLink = "https://api.whatsapp.com/send?phone=51978883199";
           <!-- Botón WhatsApp 15 soles -->
           <a
             href={whatsappLink}
+            title="Enviar mensaje por WhatsApp" 
             target="_blank"
             rel="noopener noreferrer"
             class="flex items-center gap-3 bg-orange-600 hover:bg-orange-700 transition text-white rounded-full px-4 sm:px-6 py-2 font-semibold text-sm lg:text-base 2xl:text-2xl my-5"
@@ -104,7 +105,7 @@ const whatsappLink = "https://api.whatsapp.com/send?phone=51978883199";
             rel="noopener noreferrer"
             class="flex items-start gap-3 text-teal-700 hover:text-teal-900 transition font-bold text-sm lg:text-base 2xl:text-2xl"
           >
-            <img src={iconUbicacionRojo.src} alt="Ubicación" class="w-8 h-8" />
+            <img src={iconUbicacionRojo.src} title="Ubicación" alt="Ubicación" class="w-8 h-8" />
             <div class="leading-relaxed">
               <p class="mb-1">
                 Los demás distritos de Lima Metropolitana<br />

--- a/src/pages/productos/ModalDetalles.astro
+++ b/src/pages/productos/ModalDetalles.astro
@@ -47,6 +47,7 @@ const modalImage = linkImages[link] || linkImages["default"];
           id="modal-product-img"
           src={modalImage}
           alt={`Imagen para ${link}`}
+          title={`Imagen para ${link}`}
           class="h-full w-auto object-cover"
           loading="lazy"
           onError="this.onerror=null; this.src='/images/popup/default.webp'"

--- a/src/pages/productos/detalle.astro
+++ b/src/pages/productos/detalle.astro
@@ -21,6 +21,7 @@ const productosUrl = config.endpoints.productos;
             <img
               src={ArrowProducts.src}
               alt="Flecha"
+              title="Flecha"
               class="w-full h-full"
               loading="lazy"
             />
@@ -57,7 +58,8 @@ const productosUrl = config.endpoints.productos;
         <img
           id="product-img"
           src=""
-          alt=""
+          alt="Imagen del producto"
+          title="Imagen del producto"
           class="w-3/4 md:w-4/5 h-3/4 md:h-4/5 object-contain mx-auto"
           loading="lazy"
         />
@@ -76,7 +78,8 @@ const productosUrl = config.endpoints.productos;
             <img
               id="product-viewer"
               src=""
-              alt=""
+              alt="Imagen del producto"
+              title="Imagen del producto"
               class="w-full h-full object-contain"
               loading="lazy"
             />
@@ -111,6 +114,7 @@ const productosUrl = config.endpoints.productos;
                 <img
                   src={boxSize.src}
                   alt="Box Size"
+                  title="Box Size"
                   class="w-full h-auto"
                   loading="lazy"
                 />
@@ -253,6 +257,7 @@ const productosUrl = config.endpoints.productos;
         const img = document.createElement("img");
         img.src = `${getApiUrl}${image.url_imagen}`;
         img.alt = `${product.titulo} - Vista ${index + 1}`;
+        img.title = product.titulo;
         img.className = "w-full h-full object-cover";
         div.appendChild(img);
         div.onclick = () => {
@@ -297,6 +302,7 @@ const productosUrl = config.endpoints.productos;
       const img = document.createElement("img");
       img.src = `${getApiUrl}${prod.imagenes?.[0]?.url_imagen || "/placeholder.png"}`;
       img.alt = prod.titulo;
+      img.title = prod.titulo;
       img.loading = "lazy";
       img.className =
         "w-full h-full object-cover group-hover:scale-105 transition";

--- a/src/pages/productos/detalle.astro
+++ b/src/pages/productos/detalle.astro
@@ -9,7 +9,7 @@ const getApiUrl = config.apiUrl;
 const productosUrl = config.endpoints.productos;
 ---
 
-<Layout title="Product Details">
+<Layout title="Product Details" description="Descripcion por defecto" canonicalUrl="https://tamimaquinarias.com/productos">
   <div class="w-full">
     {/* -------------------- HERO -------------------- */}
     <div
@@ -269,7 +269,25 @@ const productosUrl = config.endpoints.productos;
     }
 
     displaySpecsAndDimensions(product.especificaciones, product.dimensiones);
-    document.title = `${product.titulo} - Detalles del Producto`;
+    document.title = product.etiqueta?.meta_titulo;
+
+    console.log("product",product);
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.name = "description";
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.content = product.etiqueta?.meta_descripcion || 'Descripción por defecto';
+
+    let canonicalLink = document.querySelector('link[rel="canonical"]');
+    if (!canonicalLink) {
+      canonicalLink = document.createElement('link');
+      canonicalLink.rel = 'canonical';
+      document.head.appendChild(canonicalLink);
+    }
+    canonicalLink.href = `https://tamimaquinarias.com/productos/${product.link}`;
+
     productNameToIdMap[product.link] = product.id;
     localStorage.setItem(`product_${product.link}`, product.link);
   }

--- a/src/pages/productos/detalle.astro
+++ b/src/pages/productos/detalle.astro
@@ -271,7 +271,6 @@ const productosUrl = config.endpoints.productos;
     displaySpecsAndDimensions(product.especificaciones, product.dimensiones);
     document.title = product.etiqueta?.meta_titulo;
 
-    console.log("product",product);
     let metaDescription = document.querySelector('meta[name="description"]');
     if (!metaDescription) {
       metaDescription = document.createElement('meta');
@@ -286,7 +285,7 @@ const productosUrl = config.endpoints.productos;
       canonicalLink.rel = 'canonical';
       document.head.appendChild(canonicalLink);
     }
-    canonicalLink.href = `https://tamimaquinarias.com/productos/${product.link}`;
+    canonicalLink.href = `https://tamimaquinarias.com/productos/detalle?link=${encodeURIComponent(product.link)}`;
 
     productNameToIdMap[product.link] = product.id;
     localStorage.setItem(`product_${product.link}`, product.link);

--- a/src/pages/productos/detalle.astro
+++ b/src/pages/productos/detalle.astro
@@ -354,6 +354,89 @@ const productosUrl = config.endpoints.productos;
       removeLoader();
       displayProductDetails(product);
 
+      const images = [
+        ...(product.imagenes?.map((img) => `https://apitami.tamimaquinarias.com${img.url_imagen}`) || [])
+      ];
+
+      const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        name: product.nombre,
+        image: images,
+        description: product.descripcion,
+        sku: `PROD-${product.id}`,
+        brand: {
+          "@type": "Brand",
+          name: "Tami Maquinarias",
+          logo: "https://tamimaquinarias.com/_astro/logo-estatico-100x116.B0Pf3Br1.webp",
+          url: "https://tamimaquinarias.com/",
+        },
+        url: `https://tamimaquinarias.com/productos/detalle/?link=${encodeURIComponent(product.link)}`,
+        category: product.seccion,
+        review: [
+          {
+            "@type": "Review",
+            author: {
+              "@type": "Person",
+              name: "Nilton Ramos"
+            },
+            datePublished: "2025-09-19",
+            reviewBody: "Un excelente producto, seguramente volveré por más.",
+            name: "Todo lo que necesito.",
+            reviewRating: {
+              "@type": "Rating",
+              bestRating: "5",
+              ratingValue: "4",
+              worstRating: "1"
+            }
+          },
+          {
+            "@type": "Review",
+            author: {
+              "@type": "Person",
+              name: "María López"
+            },
+            datePublished: "2025-08-10",
+            reviewBody: "Muy buena calidad y entrega rápida. Recomiendo totalmente.",
+            name: "Entrega rápida y confiable",
+            reviewRating: {
+              "@type": "Rating",
+              bestRating: "5",
+              ratingValue: "5",
+              worstRating: "1"
+            }
+          },
+          {
+            "@type": "Review",
+            author: {
+              "@type": "Person",
+              name: "Carlos Fernández"
+            },
+            datePublished: "2025-07-22",
+            reviewBody: "Producto conforme a la descripción, buen soporte del vendedor.",
+            name: "Satisfecho con la compra",
+            reviewRating: {
+              "@type": "Rating",
+              bestRating: "5",
+              ratingValue: "4",
+              worstRating: "1"
+            }
+          }
+        ],
+        aggregateRating: {
+          "@type": "AggregateRating",
+          ratingValue: 88,
+          bestRating: 100,
+          ratingCount: 20
+        }
+      };
+
+      const script = document.createElement('script');
+      script.type = 'application/ld+json';
+      script.innerHTML = JSON.stringify(jsonLd, null, 2);
+      console.log(JSON.stringify(jsonLd, null, 2));
+      document.head.appendChild(script);
+
       // Botones cotización → WhatsApp
       ["btnQuotationHero", "btnQuotationDetail"].forEach((id) => {
         const btn = document.getElementById(id);


### PR DESCRIPTION
**Se establecieron los siguientes objetivos:**
- Visualizar title tanto para imágenes como links
- Tener un título y descripción adecuadas en la web.
- Añadir campos del summary restantes.

### Primer objetivo
En todas las páginas del navbar, así como las específicas de productos y blogs ya se puede visualizar los title.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/faf1bd97-1969-4152-96d7-fbb4b9b66604" />

### Segundo objetivo
La web toma los datos de cada blog o producto, que es donde estos puntos flaqueaban. Se recomienda llenar los ```meta_titulo``` y ````meta_descripcion``` ya que algunos están vacíos.
<img width="608" height="599" alt="image" src="https://github.com/user-attachments/assets/2684caa0-5f6a-4155-bab1-0e2e394aa10b" />

### Tercer objetivo
No se contaba con robots, author, canonical url y el lenguaje estaba con "en" 
<img width="410" height="209" alt="image" src="https://github.com/user-attachments/assets/aae496e4-2257-4de9-bfb2-f971cf927424" />
